### PR TITLE
Support config.json and pass environment variables into ninja.build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 /test/fixtures/config_filter/random-copy
 /test/fixtures/config_filter/one/random-copy
 /test/fixtures/config_filter/other/random-copy
+/test/fixtures/env/success
 /test/fixtures/multiple-output/a
 /test/fixtures/multiple-output/b
 /test/fixtures/rjs/app.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
-  "esnext": "true",
-  "moz": "true"
+  "esnext": true,
+  "moz": true,
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "bin": "./bin/confidant",
   "license": "MPL-2.0",
   "main": "./build/main",
-
   "dependencies": {
     "argparse": "^1.0.2",
     "babel": "^5.6.14",
@@ -14,17 +13,14 @@
     "lodash": "^3.9.3",
     "mz": "^2.0.0"
   },
-
   "devDependencies": {
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "mocha": "^2.2.5"
   },
-
   "engines": {
     "node": ">=0.12"
   },
-
   "scripts": {
     "prepublish": "mkdir -p build && ./node_modules/.bin/babel src --out-dir build --source-maps",
     "test": "./node_modules/.bin/mocha"

--- a/src/find_stream.js
+++ b/src/find_stream.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Executes find and sends the results through a stream.
  */
+
 let Readable = require('stream').Readable;
 let debug = require('debug')('confidant/find_stream');
 let exec = require('mz/child_process').exec;

--- a/src/main.js
+++ b/src/main.js
@@ -21,16 +21,22 @@ parser.addArgument(['--exclude'], {
   defaultValue: 'bower_components,node_modules'
 });
 
-module.exports = function main(args=parser.parseArgs()) {
+module.exports = function main(args = parser.parseArgs()) {
   let dir = args.dir;
   let readerOpts = {};
   let exclude = args.exclude;
+
   if (exclude) {
     readerOpts.exclude = exclude.split(',');
   }
 
   let reader = new FindStream(dir, readerOpts);
   let writer = createWriteStream(`${dir}/build.ninja`);
-  reader.pipe(new NinjaStream()).pipe(writer);
+  let ninja = new NinjaStream();
+
+  reader
+    .pipe(ninja)
+    .pipe(writer);
+
   return new Promise(resolve => writer.on('finish', resolve));
 };

--- a/src/ninja_stream.js
+++ b/src/ninja_stream.js
@@ -1,8 +1,8 @@
 /**
  * @fileoverview A stream that reads in confidant's configuration files
- *     and writes out ninja build rules.
+ *               and writes out ninja build rules.
  */
-let Readable = require('stream').Readable;
+
 let Transform = require('stream').Transform;
 let debug = require('debug')('confidant/ninja_stream');
 let dirname = require('path').dirname;
@@ -20,8 +20,8 @@ function NinjaStream() {
 # more configure.js files.
 `);
 }
+
 inherits(NinjaStream, Transform);
-module.exports = NinjaStream;
 
 NinjaStream.prototype._transform = function(file, encoding, done) {
   debug(`Parsing ${file}`);
@@ -40,7 +40,9 @@ NinjaStream.prototype._transform = function(file, encoding, done) {
 NinjaStream.prototype._syncTransform = function(file, encoding, tasks, done) {
   let contents = readFileSync(file);
   let dir = dirname(file);
+
   debug(`Checking ${file}... found ${tasks.length} tasks`);
+
   tasks.forEach(task => {
     let rule = `rule-${this.id++}`;
     let js = task.rule.toString();  // Function.prototype.toString
@@ -68,7 +70,7 @@ NinjaStream.prototype._syncTransform = function(file, encoding, tasks, done) {
 
     this.push(`
 rule ${rule}
-  command = cd ${dir} && node -e "${cmd}"
+  command = cd ${dir} && ${envToString(process.env)} node -e "${cmd}"
 
 build ${outputs}: ${rule} ${inputs.join(' ')}
 `);
@@ -88,3 +90,15 @@ NinjaStream.prototype._asyncTransform = function(file, encoding, RuleStream, don
 function ninjaEscape(str) {
   return str.replace(new RegExp('\\$', 'g'), '$$$$');
 }
+
+function envToString(env) {
+  let str = '';
+
+  for (let key in env) {
+    str += `${key}='${env[key]}' `;
+  }
+
+  return str.trim();
+}
+
+module.exports = NinjaStream;

--- a/test/fixtures/env/configure.js
+++ b/test/fixtures/env/configure.js
@@ -1,0 +1,13 @@
+var exec = require('child_process').execSync;
+
+module.exports = [
+  {
+    inputs: [],
+    outputs: 'success',
+    rule: function() {
+      if (process.env.ENV_TEST === '1') {
+        exec(`echo ${process.env.ENV_TEST} > success`);
+      }
+    }
+  }
+];

--- a/test/main_test.js
+++ b/test/main_test.js
@@ -59,12 +59,23 @@ let testCases = [
         `${dir}/d`
       ].map(checkExists));
     }
+  },
+  {
+    name: 'passing environment variables',
+    dir: `${__dirname}/fixtures/env`,
+    verify: function() {
+      let dir = this.dir;
+      return Promise.all([
+        `${dir}/success`
+      ].map(checkExists));
+    }
   }
 ];
 
 suite('main', function() {
   testCases.forEach(testCase => {
     test(testCase.name, function() {
+      process.env.ENV_TEST = 1;
       let dir = testCase.dir;
       let execOpts = { cwd: dir, env: process.env };
       return exec('npm install', execOpts)


### PR DESCRIPTION
According issue #31.

A scenario comes out of my mind to build Gaia would be:

```
DEBUG=1 MYPATH=path/to/somewhere bin/confidant . --config ./build-config.json
```

This patch is able to merge given variables such as DEBUG=1 MYPATH=path/to/somewhere and config variables inside build-config.json as a string of variables in order to pass them into build.ninja.

The idea of build-config.json can treat as a build config interface which should contain all build variables / flags and override by input / exports environment variables.

A build-config.json

``` json
{
  "DEBUG": 1,
  "MYPATH": "path/to/somewhere"
}
```

If user inputs variables that are inexistent in build-config.json that will not pass into build.ninja because they should be defined in build-config interface.
