### PR TITLE
Ignore env vars prefix with npm_

### DIFF
--- a/src/ninja_stream.js
+++ b/src/ninja_stream.js
@@ -112,7 +112,9 @@ function envToString(env) {
   let str = '';
 
   for (let key in env) {
-    str += `${envEscape(key)}='${envEscape(env[key])}' `;
+    if (key.indexOf('npm_') !== 0) {
+      str += `${envEscape(key)}='${envEscape(env[key])}' `;
+    }
   }
 
   return str.trim();


### PR DESCRIPTION
Otherwise, error log will include too many npm_config_xxx='..' npm_package_xxx='...' vars that hurts our development progress.

@gaye what do you think?
