### PR TITLE
Fix babel/polyfill import order

### DIFF
--- a/bin/confidant
+++ b/bin/confidant
@@ -1,4 +1,3 @@
 #!/usr/bin/env node
 
-require('babel/polyfill');
 require('../build/main')();

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+require('babel/polyfill');
+
 let ArgumentParser = require('argparse').ArgumentParser;
 let FindStream = require('./find_stream');
 let NinjaStream = require('./ninja_stream');


### PR DESCRIPTION
@gaye 

If we import module programmatically by

``` js
var confidant = require('confidant');
// confidant can be invoked with an object representing its command line args
confidant({
  dir: './path/to/somewhere',
  exclude: 'bower_components,node_modules'  // Or whatever else
});
```

In this step that is lack of `require('babel/polyfill');` for supporting necessary ES6 polyfills, so we should move import order to fix it.
